### PR TITLE
Add casting directors list endpoint and page

### DIFF
--- a/sirius-backend/src/main/java/ca/siriustalent/backend/api/controller/CastingController.java
+++ b/sirius-backend/src/main/java/ca/siriustalent/backend/api/controller/CastingController.java
@@ -3,6 +3,7 @@ package ca.siriustalent.backend.api.controller;
 import ca.siriustalent.backend.api.model.ProjectBody;
 import ca.siriustalent.backend.model.entities.Project;
 import ca.siriustalent.backend.service.CastingService;
+import ca.siriustalent.backend.model.entities.Casting;
 import jakarta.validation.Valid;
 import ca.siriustalent.backend.api.model.ProductionDayBody;
 import ca.siriustalent.backend.model.entities.LocalUser;
@@ -60,6 +61,21 @@ public class CastingController {
     public ResponseEntity<List<LocalUser>> getAllPerformersByIds(@RequestParam List<String> ids) {
         List<LocalUser> performers = userService.getAllUsersByListIds(ids);
         return new ResponseEntity<>(performers, HttpStatus.OK);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<?> getAllCastingDirectors(@RequestHeader("Authorization") String jwtToken) {
+        try {
+            String token = jwtToken.replace("Bearer ", "");
+            if (!jwtUtil.extractRole(token).equals("Admin")) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Access denied");
+            }
+
+            List<Casting> castings = castingService.getAllCastingDirectors();
+            return ResponseEntity.ok(castings);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or missing token");
+        }
     }
 
 

--- a/sirius-backend/src/main/java/ca/siriustalent/backend/service/CastingService.java
+++ b/sirius-backend/src/main/java/ca/siriustalent/backend/service/CastingService.java
@@ -46,4 +46,8 @@ public class CastingService {
     public List<Project> getAllProjects() {
         return projectRepository.findAll();
     }
+
+    public List<Casting> getAllCastingDirectors() {
+        return castingRepository.findAll();
+    }
 }

--- a/sirius-frontend/src/App.tsx
+++ b/sirius-frontend/src/App.tsx
@@ -48,6 +48,7 @@ import ProjectAll from "./pages/Project/ProjectAll.tsx";
 import {ProjectNewDays} from "./pages/Project/ProjectNewDays.tsx";
 import ProjectDay from "./pages/Project/ProjectDay.tsx";
 import {AdminProjects} from "./pages/AdminProjects.tsx";
+import {AdminCastingDirectors} from "./pages/AdminCastingDirectors.tsx";
 import {TokenJwtPayload} from "./components/LoginForm/LoginForm.tsx";
 import {adminNavigation} from "./templates/adminNavigation.ts";
 import {AdminNavigation} from "./components/AdminNavigation/AdminNavigation.tsx";
@@ -131,6 +132,7 @@ const App: React.FC = () => {
                                 <Route path="/admin/user-update/:id" element={<AdminUpdateUser />} />
                                 <Route path="/admin/user-create" element={<AdminUserCreate />} />
                                 <Route path="/admin/projects" element={<AdminProjects />} />
+                                <Route path="/admin/casting-directors" element={<AdminCastingDirectors />} />
                                 <Route path="/admin/user/email-to/:id" element={<AdminSendEmailToUser />} />
 
                                 <Route path="/project/create/:castingId" element={<ProjectCreate />} />

--- a/sirius-frontend/src/pages/AdminCastingDirectors.tsx
+++ b/sirius-frontend/src/pages/AdminCastingDirectors.tsx
@@ -1,3 +1,7 @@
-export const AdminCastingDirectors = () => {
+import CastingDirectorsAll from "./CastingDirectorsAll";
 
-}
+export const AdminCastingDirectors = () => {
+    return (
+        <CastingDirectorsAll/>
+    );
+};

--- a/sirius-frontend/src/pages/CastingDirectorsAll.tsx
+++ b/sirius-frontend/src/pages/CastingDirectorsAll.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+
+interface CastingDirector {
+    id: string;
+    email: string;
+    tel: string;
+}
+
+const CastingDirectorsAll: React.FC = () => {
+    const [castingDirectors, setCastingDirectors] = useState<CastingDirector[]>([]);
+
+    useEffect(() => {
+        const fetchCastingDirectors = async () => {
+            const token = localStorage.getItem("token");
+            if (!token) return;
+
+            try {
+                const response = await axios.get(`${import.meta.env.VITE_API_URL}/api/casting/all`, {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    }
+                });
+                setCastingDirectors(response.data);
+            } catch (error) {
+                console.error("Failed to fetch casting directors:", error);
+            }
+        };
+
+        fetchCastingDirectors();
+    }, []);
+
+    return (
+        <div>
+            <h2>All Casting Directors</h2>
+            <ul>
+                {castingDirectors.map(cd => (
+                    <li key={cd.id}>{cd.email} ({cd.tel})</li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default CastingDirectorsAll;


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch all casting directors
- expose service method for retrieving casting directors
- display casting directors in new `CastingDirectorsAll` page
- hook page into admin navigation and routing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./mvnw -q test` *(fails: network access to Maven Central blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68599ae108108332835429c7c700b601